### PR TITLE
Add missing dependency on docker binary

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,8 @@
   ],
   "auth": "zef:jnthn",
   "depends": [
-    "JSON::Fast"
+    "JSON::Fast",
+    "docker:from<bin>"
   ],
   "build-depends": [],
   "test-depends": [],


### PR DESCRIPTION
Gives at least better error messages when Docker is not installed.