### PR TITLE
Remove log tables from ClickHouse

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name": "Dev::ContainerizedService",
   "description": "Uses containers to provide services (such as databases) to ease getting a local development environment set up.",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "perl": "6.*",
   "authors": [
     "Jonathan Worthington <jnthn@jnthn.net>"

--- a/lib/Dev/ContainerizedService/Spec/ClickHouse.rakumod
+++ b/lib/Dev/ContainerizedService/Spec/ClickHouse.rakumod
@@ -8,6 +8,22 @@ my constant $CONFIG = q:to/CONFIG/;
             <console>1</console>
             <level>error</level>
         </logger>
+
+        <asynchronous_metric_log remove="1"/>
+        <backup_log remove="1"/>
+        <error_log remove="1"/>
+        <metric_log remove="1"/>
+        <query_thread_log remove="1" />  
+        <query_log remove="1" />
+        <query_views_log remove="1" />
+        <part_log remove="1"/>
+        <session_log remove="1"/>
+        <text_log remove="1" />
+        <trace_log remove="1"/>
+        <crash_log remove="1"/>
+        <opentelemetry_span_log remove="1"/>
+        <zookeeper_log remove="1"/>
+        <processors_profile_log remove="1"/>
     </clickhouse>
     CONFIG
 


### PR DESCRIPTION
Since the ClickHouse container is used for development only, it's unlikely that anyone is interested in e.g. performance metrics of the server. Keeping them causes ClickHouse to consume a bit of CPU quite frequently which may cause some fan spinning up, costing precious developer concentration. It can also fill up disks. So disable those tables.